### PR TITLE
[JENKINS-25111] Fix problem when using folders

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
@@ -57,7 +57,7 @@ public class MultiJobBuildSelector extends BuildSelector {
         // Get the run for our source Job in the current MultiJob Project's Build
         for (MultiJobBuild.SubBuild subBuild : multiJobBuild.getSubBuilds()) {
             // Find Job's specific build we want
-            if (subBuild.getJobName().equals(job.getFullDisplayName())) {
+            if (subBuild.getJobName().equals(job.getDisplayName())) {
                 Run run = job.getBuildByNumber(subBuild.getBuildNumber());
                 if (filter.isSelectable(run, env)) {
                     return run;


### PR DESCRIPTION
As mentioned in a comment of the JENKINS-25111 issue, the Multijob build selector does not work when using folders. The problem is due to the use of getFullDisplayName() instead of getDisplayName() when looking for a sub build. getFullDisplayName() includes the parent names whereas sub build's job name contains only the job name. It's the reason the check couldn't find a match.